### PR TITLE
Fix outdated info being shown after page loses focus for too long

### DIFF
--- a/static/js/indexConnect.js
+++ b/static/js/indexConnect.js
@@ -204,3 +204,27 @@ var x = setInterval(async function() {
         });
     }
 }, 1000);
+
+
+// When the app gets put into the background, the browser pauses execution of the code.
+// This frequently causes the bus app to miss updates, and means it has to be reloaded or restarted.
+// This code checks if there is a significant discrepancy in how long since the code last ran,
+// if there is a discrepancy, reload the page once it regains focus.
+
+var lastTime = (new Date()).getTime();
+// set the interval for every 30 seconds
+const reloadChecker = setInterval(async function() {
+    var currentTime = (new Date()).getTime();
+    console.log(currentTime - lastTime);
+    // check if it has been significantly more than 30 seconds, this would indicate code execution was paused or throttled
+    // also check if the page is visible - if it already is then a reload wont help it
+    if (currentTime > (lastTime + 40000) && document.visibilityState !== "visible") {
+        document.addEventListener("visibilitychange", (event) => {
+            // once the page is visible again, we reload it!
+            if (document.visibilityState === "visible") { window.location.reload(); }
+        });
+        // clear the interval, the reload is primed and there is nothing more to be done
+        clearInterval(reloadChecker);
+    }
+    lastTime = currentTime;
+}, 30000);

--- a/static/js/indexConnect.js
+++ b/static/js/indexConnect.js
@@ -215,7 +215,7 @@ var lastTime = (new Date()).getTime();
 // set the interval for every 30 seconds
 const reloadChecker = setInterval(async function() {
     var currentTime = (new Date()).getTime();
-    console.log(currentTime - lastTime);
+    //console.log(currentTime - lastTime);
     // check if it has been significantly more than 30 seconds, this would indicate code execution was paused or throttled
     // also check if the page is visible - if it already is then a reload wont help it
     if (currentTime > (lastTime + 40000) && document.visibilityState !== "visible") {

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -17,7 +17,7 @@
         <script src="js/ejs.js"></script>
         <script src="/socket.io/socket.io.js"></script>
         <script id="getRender" render="<%= render %>" src='js/adminConnect.js'></script>
-        <script src="js/adminConnect.js"></script>
+        <!--script src="js/adminConnect.js"></script-->
         <script src="js/formVerification.js"></script>
         <script src="js/networkIndicator.js"></script>
     </body>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -16,7 +16,7 @@
         </div>
         <script src="js/pushNotifs.js"></script>
         <script src="/socket.io/socket.io.js"></script>
-        <script src='js/indexConnect.js'></script>
+        <!--script src='js/indexConnect.js'></script-->
         <script src="js/ejs.js"></script>
         <script src="js/networkIndicator.js"></script>
         <script id="getRender" render="<%= render %>" src='js/indexConnect.js'></script>


### PR DESCRIPTION
when page regains visibility *and* execution was paused, the page now reloads automatically to ensure up to date info is displayed